### PR TITLE
surfaceflinger: Fix the "Fix the opaque check"

### DIFF
--- a/services/surfaceflinger/Layer.cpp
+++ b/services/surfaceflinger/Layer.cpp
@@ -478,7 +478,7 @@ void Layer::setGeometry(
 
     // this gives us only the "orientation" component of the transform
     const State& s(getDrawingState());
-#ifdef QCOM_BSP
+#if defined(QCOM_BSP) && !defined(QCOM_BSP_LEGACY)
     if (!isOpaque(s))
 #else
     if (!isOpaque(s) || s.alpha != 0xFF)


### PR DESCRIPTION
 * QCOM_BSP_LEGACY should use the second choice.

Change-Id: I993fb08f648eab70ae215ee39864bc5914c01123